### PR TITLE
changes to recoil derivation/application as Oct19

### DIFF
--- a/Recoil/fitRecoilZmm.C
+++ b/Recoil/fitRecoilZmm.C
@@ -13,6 +13,7 @@
 #include <TFile.h>                    // file handle class
 #include <TTree.h>                    // class to access ntuples
 #include <TF1.h>                      // 1D function
+#include <TLatex.h>
 #include <TFitResult.h>               // class to handle fit results
 #include <TGraphErrors.h>             // graph class
 #include "TLorentzVector.h"           // 4-vector class
@@ -27,16 +28,23 @@
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"
 #include "RooHistPdf.h"
+#include "RooKeysPdf.h"
 #include "RooPlot.h"
 #include "RooFitResult.h"
 #include "RooDataHist.h"
 #include "RooWorkspace.h"
 #include "RooFormulaVar.h"
 #include "RooRealIntegral.h"
+#include "Math/MinimizerOptions.h"
+#include "Math/Minimizer.h"
+
 #endif
 
 using namespace RooFit;
 using namespace std;
+
+bool do_keys=true;
+
 
 //=== FUNCTION DECLARATIONS ======================================================================================
 
@@ -126,6 +134,7 @@ Double_t dSigma(const TF1 *fcn, const Double_t x, const TFitResultPtr fs) {
 // perform fit of recoil component
 void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_t *ptbins, const Int_t nbins,
                 const Int_t model, const Bool_t sigOnly,
+		const vector<RooDataSet> lDataSet, const vector<RooRealVar> lVar,
                 TCanvas *c, const char *plabel, const char *xlabel,
                 Double_t *mean1Arr,   Double_t *mean1ErrArr,
                 Double_t *mean2Arr,   Double_t *mean2ErrArr,
@@ -136,7 +145,9 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
                 Double_t *sigma3Arr, Double_t *sigma3ErrArr,
                 Double_t *frac2Arr,  Double_t *frac2ErrArr,
                 Double_t *frac3Arr,  Double_t *frac3ErrArr,
-                RooWorkspace *workspace);
+		Double_t *chi2Arr,   Double_t *chi2ErrArr,
+                RooWorkspace *workspace,
+		int etaBinCategory);
                 
 void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_t *ptbins, const Int_t nbins,
                 const Int_t model, const Bool_t sigOnly,
@@ -158,12 +169,13 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
 void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuples/data_select.root",  // input ntuple
                   Int_t   pfu1model=2,   // u1 model (1 => single Gaussian, 2 => double Gaussian, 3 => triple Gaussian)
                   Int_t   pfu2model=2,   // u2 model (1 => single Gaussian, 2 => double Gaussian, 3 => triple Gaussian)
-	              Bool_t  sigOnly=1,     // signal event only?
+		  Bool_t  sigOnly=1,     // signal event only?
                   std::string uparName = "u1",
                   std::string uprpName = "u2",
                   std::string metName = "pf",
                   TString outputDir="./", // output directory
-                  Double_t lumi=1
+                  Double_t lumi=1,
+		  int etaBinCategory=0 // 0 is inclusive, 1 is fabs(eta)<=0.5,  2 is fabs(eta)=[0.5,1], 3 is fabs(eta)>=1
 ) {
 
   //--------------------------------------------------------------------------------------------------------------
@@ -176,21 +188,22 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
 //   Double_t ptbins[] = {5,10,20,30,40,50};
 //   
   // specify your desired pT binning here. Currently using very narrow bins
-  Double_t ptbins[] = {0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,62.5,65,67.5,70,72.5,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
-  Int_t nbins = sizeof(ptbins)/sizeof(Double_t)-1;
+  // oct2 binning below
+  //  Double_t ptbins[] = {0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,62.5,65,67.5,70,72.5,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
+  // oct7 binning below
+  Double_t ptbins[] = {0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,65,70,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
 
+  Int_t nbins = sizeof(ptbins)/sizeof(Double_t)-1;
   Double_t corrbins[] = { 0, 10, 30, 50 };
   Int_t ncorrbins = sizeof(corrbins)/sizeof(Double_t)-1;
 
-  TString formulaPFu1mean("pol1");
-  TString formulaPFu2mean("pol1");
-
-//     TString formulaPFu1mean("pol2");
-//   TString formulaPFu2mean("pol2");
+  TString formulaPFu1mean("pol2");
+  TString formulaPFu2mean("pol2");
   
   vector<TString> fnamev;
   vector<Bool_t> isBkgv;
   fnamev.push_back(infilename); isBkgv.push_back(kFALSE);
+  fnamev.push_back("/afs/cern.ch/work/a/arapyan/public/flat_ntuples//Zmumu/ntuples/top_select.raw.root"); isBkgv.push_back(kTRUE);
 //   
   const Double_t MASS_LOW  = 60;
   const Double_t MASS_HIGH = 120;  
@@ -205,12 +218,40 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   char hname[100];
   vector<TH1D*> hPFu1v,  hPFu1Bkgv;
   vector<TH1D*> hPFu2v,  hPFu2Bkgv;
+  vector<RooDataSet> lDataSetU1;
+  vector<RooDataSet> lDataSetU2;
+
+  vector<RooRealVar> vu1Var;
+  vector<RooRealVar> vu2Var;
+
+  RooWorkspace pdfsU1("pdfsU1");
+  RooWorkspace pdfsU2("pdfsU2");
+
   for(Int_t ibin=0; ibin<nbins; ibin++) {
-    sprintf(hname,"hPFu1_%i",ibin);    hPFu1v.push_back(new TH1D(hname,"",100,-100-ptbins[ibin],100-ptbins[ibin]));    hPFu1v[ibin]->Sumw2();
-    sprintf(hname,"hPFu1Bkg_%i",ibin); hPFu1Bkgv.push_back(new TH1D(hname,"",100,-100-ptbins[ibin],100-ptbins[ibin])); hPFu1Bkgv[ibin]->Sumw2();
+
+    int range=100;
+    if(ptbins[ibin]>80) range=125;
+    if(ptbins[ibin]>150) range=150;
+    sprintf(hname,"hPFu1_%i",ibin);    hPFu1v.push_back(new TH1D(hname,"",100,-range-ptbins[ibin],range-ptbins[ibin]));    hPFu1v[ibin]->Sumw2();
+    sprintf(hname,"hPFu1Bkg_%i",ibin); hPFu1Bkgv.push_back(new TH1D(hname,"",50,-range-ptbins[ibin],range-ptbins[ibin]));  hPFu1Bkgv[ibin]->Sumw2();
     
-    sprintf(hname,"hPFu2_%i",ibin);    hPFu2v.push_back(new TH1D(hname,"",100,-100,100));    hPFu2v[ibin]->Sumw2();	       
-    sprintf(hname,"hPFu2Bkg_%i",ibin); hPFu2Bkgv.push_back(new TH1D(hname,"",100,-100,100)); hPFu2Bkgv[ibin]->Sumw2();
+    //    sprintf(hname,"hPFu2_%i",ibin);    hPFu2v.push_back(new TH1D(hname,"",100,-range,range));    hPFu2v[ibin]->Sumw2();
+    //    sprintf(hname,"hPFu2Bkg_%i",ibin); hPFu2Bkgv.push_back(new TH1D(hname,"",100,-range,range)); hPFu2Bkgv[ibin]->Sumw2();
+    sprintf(hname,"hPFu2_%i",ibin);    hPFu2v.push_back(new TH1D(hname,"",100,-range,range));    hPFu2v[ibin]->Sumw2();
+    sprintf(hname,"hPFu2Bkg_%i",ibin); hPFu2Bkgv.push_back(new TH1D(hname,"",50,-range,range));  hPFu2Bkgv[ibin]->Sumw2();
+
+    std::stringstream name;
+    name << "u_" << ibin;
+
+    RooRealVar u1Var(name.str().c_str(),name.str().c_str(), 0, -range-ptbins[ibin], range-ptbins[ibin]);
+    RooRealVar u2Var(name.str().c_str(),name.str().c_str(), 0, -range, range);
+
+    vu1Var.push_back(u1Var);
+    vu2Var.push_back(u2Var);
+
+    sprintf(hname,"hDataSetU1_%i",ibin);  RooDataSet dataSetU1(hname,hname,RooArgSet(u1Var)); lDataSetU1.push_back(dataSetU1);
+    sprintf(hname,"hDataSetU2_%i",ibin);  RooDataSet dataSetU2(hname,hname,RooArgSet(u2Var)); lDataSetU2.push_back(dataSetU2);
+
   }
 
   vector<TH2D*> hPFu1u2v;
@@ -219,10 +260,14 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
     hPFu1u2v.push_back(new TH2D(hname,"",300,-10,10,300,-10,10));
   }
   
-    
+
+  TFitResultPtr fitresPFu1mean;   TF1 *fcnPFu1mean   = new TF1("fcnPFu1mean",formulaPFu1mean,0,7000);
+  TFitResultPtr fitresPFu1mean2;  TF1 *fcnPFu1mean2  = new TF1("fcnPFu1mean2",formulaPFu1mean,0,7000);
+  TFitResultPtr fitresPFu1mean3;  TF1 *fcnPFu1mean3  = new TF1("fcnPFu1mean3",formulaPFu1mean,0,7000);
+
   TFile *infile = 0;
   TTree *intree = 0;  
-  
+
   //
   // Declare output ntuple variables
   //
@@ -231,7 +276,7 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   UInt_t  category;
   UInt_t  npv, npu;
   Float_t genVPt, genVPhi, genVy, genVMass;
-  Float_t scale1fb;
+  Float_t scale1fb,scale1fbUp,scale1fbDown;
   Float_t met, metPhi, sumEt, u1, u2; // pf met
   Float_t mvaMet, mvaMetPhi, mvaSumEt, mvaU1, mvaU2; // mva met
   Float_t ppMet, ppMetPhi, ppSumEt, ppU1, ppU2; // pf type 1
@@ -258,8 +303,10 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
     intree->SetBranchAddress("genVy",    &genVy);      // GEN boson rapidity (signal MC)
     intree->SetBranchAddress("genVMass", &genVMass);   // GEN boson mass (signal MC)
     intree->SetBranchAddress("scale1fb", &scale1fb);   // event weight per 1/fb (MC)
-    
-    intree->SetBranchAddress("met",	           &met);        // Uncorrected PF MET
+    intree->SetBranchAddress("scale1fbUp", &scale1fbUp);  // event weight per 1/fb (MC)
+    intree->SetBranchAddress("scale1fbDown", &scale1fbDown);  // event weight per 1/fb (MC)
+
+    intree->SetBranchAddress("met",	       &met);        // Uncorrected PF MET
     intree->SetBranchAddress("metPhi",	       &metPhi);     // phi(MET)
     intree->SetBranchAddress("sumEt",          &sumEt);      // Sum ET
     intree->SetBranchAddress(uparName.c_str(), &u1);         // parallel component of recoil      
@@ -278,11 +325,27 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
     for(Int_t ientry=0; ientry<intree->GetEntries(); ientry++) {
       intree->GetEntry(ientry);
     
-      if(category!=1 && category!=2 && category != 3)                continue;
-      if(dilep->M() < MASS_LOW || dilep->M() > MASS_HIGH)            continue;
+      // need to gain stat on the ttbar BKG
+      if(!isBkgv[ifile]) {
+	if(category!=1 && category!=2 && category != 3)                continue;
+	if(dilep->M() < MASS_LOW || dilep->M() > MASS_HIGH)            continue;
+      }
       if(lep1->Pt()        < PT_CUT  || lep2->Pt()        < PT_CUT)  continue;
       if(fabs(lep1->Eta()) > ETA_CUT || fabs(lep2->Eta()) > ETA_CUT) continue;
-    
+
+      // need to gain stat on the ttbar BKG
+      if(!isBkgv[ifile]) {
+	if(!infilename.Contains("data_")) {
+	  if(etaBinCategory==1 && fabs(genVy)>0.5) continue;
+	  if(etaBinCategory==2 && (fabs(genVy)<=0.5 || fabs(genVy)>=1 )) continue;
+	  if(etaBinCategory==3 && fabs(genVy)<1) continue;
+	} else {
+	  if(etaBinCategory==1 && fabs(dilep->Eta())>0.5) continue;
+	  if(etaBinCategory==2 && (fabs(dilep->Eta())<=0.5 || fabs(dilep->Eta())>=1 )) continue;
+	  if(etaBinCategory==3 && fabs(dilep->Eta())<1) continue;
+	}
+      }
+
       Int_t ipt=-1;
       for(Int_t ibin=0; ibin<nbins; ibin++) {
         if(dilep->Pt() > ptbins[ibin] && dilep->Pt() <= ptbins[ibin+1])
@@ -290,13 +353,34 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
       }
       if(ipt<0) continue;
     
+      vu1Var[ipt].setVal(u1);
+      vu2Var[ipt].setVal(u2);
+      lDataSetU1[ipt].add(RooArgSet(vu1Var[ipt])); // need to add the weights
+      lDataSetU2[ipt].add(RooArgSet(vu2Var[ipt]));
+
       if(isBkgv[ifile]) {
-        hPFu1Bkgv[ipt]->Fill(u1,scale1fb*lumi);
-        hPFu2Bkgv[ipt]->Fill(u2,scale1fb*lumi);
-      
+	hPFu1Bkgv[ipt]->Fill(u1,scale1fb*lumi);
+	hPFu2Bkgv[ipt]->Fill(u2,scale1fb*lumi);
+
+	//        hPFu1Bkgv[ipt]->Fill(u1,scale1fbUp*lumi);
+	//        hPFu2Bkgv[ipt]->Fill(u2,scale1fbUp*lumi);
+
+	//	hPFu1Bkgv[ipt]->Fill(u1,scale1fbDown*lumi);
+	//	hPFu2Bkgv[ipt]->Fill(u2,scale1fbDown*lumi);
+
+
       } else {
-        hPFu1v[ipt]->Fill(u1,scale1fb*lumi);
-        hPFu2v[ipt]->Fill(u2,scale1fb*lumi);
+
+	if(infilename.Contains("data_")) lumi=1;
+	hPFu1v[ipt]->Fill(u1,scale1fb*lumi);
+	hPFu2v[ipt]->Fill(u2,scale1fb*lumi);
+
+	//	hPFu1v[ipt]->Fill(u1,scale1fbUp*lumi);
+	//	hPFu2v[ipt]->Fill(u2,scale1fbUp*lumi);
+
+	//	hPFu1v[ipt]->Fill(u1,scale1fbDown*lumi);
+	//	hPFu2v[ipt]->Fill(u2,scale1fbDown*lumi);
+
       }
     }
     
@@ -322,6 +406,7 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   TGraphErrors *grPFu1sigma3=0; Double_t pfu1Sigma3[nbins], pfu1Sigma3Err[nbins];
   TGraphErrors *grPFu1frac2=0;  Double_t pfu1Frac2[nbins],  pfu1Frac2Err[nbins];  
   TGraphErrors *grPFu1frac3=0;  Double_t pfu1Frac3[nbins],  pfu1Frac3Err[nbins];
+  TGraphErrors *grPFu1chi2=0;   Double_t pfu1chi2[nbins],   pfu1chi2Err[nbins];;
 
   TGraphErrors *grPFu2mean=0;   Double_t pfu2Mean[nbins],   pfu2MeanErr[nbins];
   TGraphErrors *grPFu2mean2=0;  Double_t pfu2Mean2[nbins],  pfu2Mean2Err[nbins];
@@ -332,25 +417,27 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   TGraphErrors *grPFu2sigma3=0; Double_t pfu2Sigma3[nbins], pfu2Sigma3Err[nbins];
   TGraphErrors *grPFu2frac2=0;  Double_t pfu2Frac2[nbins],  pfu2Frac2Err[nbins];  
   TGraphErrors *grPFu2frac3=0;  Double_t pfu2Frac3[nbins],  pfu2Frac3Err[nbins];
+  TGraphErrors *grPFu2chi2=0;   Double_t pfu2chi2[nbins],   pfu2chi2Err[nbins];
   
-  RooWorkspace pdfsU1("pdfsU1");
-  RooWorkspace pdfsU2("pdfsU2");     
   
-  TCanvas *c = MakeCanvas("c","c",800,600);
+  TCanvas *c = MakeCanvas("c","c",800,800);
 
   // Fitting PF-MET u1
   performFit(hPFu1v, hPFu1Bkgv, ptbins, nbins, pfu1model, sigOnly,
-             c, "pfu1", "PF u_{1} [GeV]",
+	     lDataSetU1, vu1Var,
+             c, "pfu1", "u_{#parallel  } [GeV]",
 	     pfu1Mean,   pfu1MeanErr,
-         pfu1Mean2,  pfu1Mean2Err,
-         pfu1Mean3,  pfu1Mean3Err,
+	     pfu1Mean2,  pfu1Mean2Err,
+	     pfu1Mean3,  pfu1Mean3Err,
 	     pfu1Sigma0, pfu1Sigma0Err,
 	     pfu1Sigma1, pfu1Sigma1Err,
 	     pfu1Sigma2, pfu1Sigma2Err,
 	     pfu1Sigma3, pfu1Sigma3Err,
 	     pfu1Frac2,  pfu1Frac2Err,
 	     pfu1Frac3,  pfu1Frac3Err,
-          &pdfsU1   );
+	     pfu1chi2,   pfu1chi2Err,
+	     &pdfsU1,
+	     etaBinCategory);
 
           
   std::cout << "writing" << std::endl;
@@ -362,17 +449,21 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   
   // Fitting PF-MET u2         
   performFit(hPFu2v, hPFu2Bkgv, ptbins, nbins, pfu2model, sigOnly,
-             c, "pfu2", "PF u_{2} [GeV]",
-         pfu2Mean,   pfu2MeanErr,
-         pfu2Mean2,  pfu2Mean2Err,
-         pfu2Mean3,  pfu2Mean3Err,
-         pfu2Sigma0, pfu2Sigma0Err,
-         pfu2Sigma1, pfu2Sigma1Err,
-         pfu2Sigma2, pfu2Sigma2Err,
-         pfu2Sigma3, pfu2Sigma3Err,
-         pfu2Frac2,  pfu2Frac2Err,
-         pfu2Frac3,  pfu2Frac3Err, &pdfsU2);  
-         
+	     lDataSetU2, vu2Var,
+             c, "pfu2", "u_{#perp  } [GeV]",
+	     pfu2Mean,   pfu2MeanErr,
+	     pfu2Mean2,  pfu2Mean2Err,
+	     pfu2Mean3,  pfu2Mean3Err,
+	     pfu2Sigma0, pfu2Sigma0Err,
+	     pfu2Sigma1, pfu2Sigma1Err,
+	     pfu2Sigma2, pfu2Sigma2Err,
+	     pfu2Sigma3, pfu2Sigma3Err,
+	     pfu2Frac2,  pfu2Frac2Err,
+	     pfu2Frac3,  pfu2Frac3Err,
+	     pfu2chi2,   pfu2chi2Err,
+	     &pdfsU2,
+	     etaBinCategory);
+
   sprintf(outpdfname,"%s/%s.root",outputDir.Data(),"pdfsU2");
   pdfsU2.writeToFile(outpdfname);
 
@@ -380,7 +471,15 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   //--------------------------------------------------------------------------------------------------------------
   // Make plots 
   //==============================================================================================================  
-   
+
+
+  TString label = "";
+  if(infilename.Contains("data")) label="Z DATA";
+  if(!infilename.Contains("data")) label="Z MC";
+  TLatex latexLabel;
+  latexLabel.SetTextSize(0.04);
+  latexLabel.SetNDC();
+
   char fitparam[100];
   char chi2ndf[50]; 
     
@@ -390,50 +489,65 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   // Plotting PF-MET u1 vs. dilepton pT
   //
   grPFu1mean = new TGraphErrors(nbins,xval,pfu1Mean,xerr,pfu1MeanErr);
+  grPFu1mean->GetYaxis()->SetRangeUser(-350., 20.);
   grPFu1mean->SetName("grPFu1mean");
-  CPlot plotPFu1mean("pfu1mean","","p_{T}(ll) [GeV/c]","#mu(u_{1}) [GeV]");
-  plotPFu1mean.AddGraph(grPFu1mean,"");
+  fitresPFu1mean = grPFu1mean->Fit("fcnPFu1mean","QMRN0FBSE");
+  sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu1mean->GetChisquare())/(fcnPFu1mean->GetNDF()));
+  CPlot plotPFu1mean("pfu1mean","","p_{T}(ll) [GeV/c]","#mu(u_{#parallel}) [GeV]");
   plotPFu1mean.AddGraph(grPFu1mean,"",kBlack,kOpenCircle);
+  plotPFu1mean.AddFcn(fcnPFu1mean,kRed);
   plotPFu1mean.AddTextBox(chi2ndf,0.65,0.87,0.95,0.82,0,kBlack,-1);
+  sprintf(fitparam,"p_{0} = %.3f #pm %.3f",fcnPFu1mean->GetParameter(0),fcnPFu1mean->GetParError(0)); plotPFu1mean.AddTextBox(fitparam,0.65,0.80,0.95,0.75,0,kBlack,-1);
+  sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu1mean->GetParameter(1),fcnPFu1mean->GetParError(1)); plotPFu1mean.AddTextBox(fitparam,0.65,0.75,0.95,0.70,0,kBlack,-1);
+  sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu1mean->GetParameter(2),fcnPFu1mean->GetParError(2)); plotPFu1mean.AddTextBox(fitparam,0.65,0.70,0.95,0.65,0,kBlack,-1);
+  latexLabel.DrawLatex(0.20, 0.2, label);
   plotPFu1mean.Draw(c,kTRUE,"png");
   
   grPFu1sigma1 = new TGraphErrors(nbins,xval,pfu1Sigma1,xerr,pfu1Sigma1Err);  
+  grPFu1sigma1->GetYaxis()->SetRangeUser(0., 50.);
   grPFu1sigma1->SetName("grPFu1sigma1");
-  CPlot plotPFu1sigma1("pfu1sigma1","","p_{T}(ll) [GeV/c]","#sigma_{1}(u_{1}) [GeV]");
-  plotPFu1sigma1.AddGraph(grPFu1sigma1,"");
+  CPlot plotPFu1sigma1("pfu1sigma1","","p_{T}(ll) [GeV/c]","#sigma_{1}(u_{#parallel}) [GeV]");
   plotPFu1sigma1.AddGraph(grPFu1sigma1,"",kBlack,kOpenCircle);
-  plotPFu1sigma1.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+  //  plotPFu1sigma1.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+  latexLabel.DrawLatex(0.20, 0.8, label);
   plotPFu1sigma1.Draw(c,kTRUE,"png");
   
   if(pfu1model>=2) {
     
     grPFu1mean2 = new TGraphErrors(nbins,xval,pfu1Mean2,xerr,pfu1Mean2Err);
+    grPFu1mean2->GetYaxis()->SetRangeUser(-350., 20.);
     grPFu1mean2->SetName("grPFu1mean2");
-    CPlot plotPFu1mean2("pfu1mean2","","p_{T}(ll) [GeV/c]","#mu(u_{1}) [GeV]");
-    plotPFu1mean2.AddGraph(grPFu1mean2,"");
+    fitresPFu1mean2 = grPFu1mean2->Fit("fcnPFu1mean2","QMRN0FBSE");
+    sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu1mean2->GetChisquare())/(fcnPFu1mean2->GetNDF()));
+    CPlot plotPFu1mean2("pfu1mean2","","p_{T}(ll) [GeV/c]","#mu(u_{#parallel}) [GeV]");
     plotPFu1mean2.AddGraph(grPFu1mean2,"",kBlack,kOpenCircle);
+    plotPFu1mean2.AddFcn(fcnPFu1mean,kRed);
     plotPFu1mean2.AddTextBox(chi2ndf,0.65,0.87,0.95,0.82,0,kBlack,-1);
+    sprintf(fitparam,"p_{0} = %.3f #pm %.3f",fcnPFu1mean2->GetParameter(0),fcnPFu1mean2->GetParError(0)); plotPFu1mean2.AddTextBox(fitparam,0.65,0.80,0.95,0.75,0,kBlack,-1);
+    sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu1mean2->GetParameter(1),fcnPFu1mean2->GetParError(1)); plotPFu1mean2.AddTextBox(fitparam,0.65,0.75,0.95,0.70,0,kBlack,-1);
+    sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu1mean2->GetParameter(2),fcnPFu1mean2->GetParError(2)); plotPFu1mean2.AddTextBox(fitparam,0.65,0.70,0.95,0.65,0,kBlack,-1);
+    latexLabel.DrawLatex(0.20, 0.2, label);
     plotPFu1mean2.Draw(c,kTRUE,"png");
     
-    
     grPFu1sigma2 = new TGraphErrors(nbins,xval,pfu1Sigma2,xerr,pfu1Sigma2Err);    
+    grPFu1sigma2->GetYaxis()->SetRangeUser(0., 50.);
     grPFu1sigma2->SetName("grPFu1sigma2");
-    CPlot plotPFu1sigma2("pfu1sigma2","","p_{T}(ll) [GeV/c]","#sigma_{2}(u_{1}) [GeV]");
-    plotPFu1sigma2.AddGraph(grPFu1sigma2,"");
+    CPlot plotPFu1sigma2("pfu1sigma2","","p_{T}(ll) [GeV/c]","#sigma_{2}(u_{#parallel}) [GeV]");
     plotPFu1sigma2.AddGraph(grPFu1sigma2,"",kBlack,kOpenCircle);
-    plotPFu1sigma2.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    //    plotPFu1sigma2.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    latexLabel.DrawLatex(0.20, 0.8, label);
     plotPFu1sigma2.Draw(c,kTRUE,"png");
 
 
     grPFu1sigma0 = new TGraphErrors(nbins,xval,pfu1Sigma0,xerr,pfu1Sigma0Err);    
     grPFu1sigma0->SetName("grPFu1sigma0");
-    CPlot plotPFu1sigma0("pfu1sigma0","","p_{T}(ll) [GeV/c]","#sigma(u_{1}) [GeV]");
-    plotPFu1sigma0.AddGraph(grPFu1sigma0,"");
+    CPlot plotPFu1sigma0("pfu1sigma0","","p_{T}(ll) [GeV/c]","#sigma(u_{#parallel}) [GeV]");
     plotPFu1sigma0.AddGraph(grPFu1sigma0,"",kBlack,kOpenCircle);
-    plotPFu1sigma0.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    //    plotPFu1sigma0.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
     plotPFu1sigma0.Draw(c,kTRUE,"png");
     
     grPFu1frac2 = new TGraphErrors(nbins,xval,pfu1Frac2, xerr,pfu1Frac2Err);
+    grPFu1frac2->GetYaxis()->SetRangeUser(0., 1.);
     grPFu1frac2->SetName("grPFu1frac2");
     CPlot plotPFu1frac2("pfu1frac2","","p_{T}(ll) [GeV/c]","f_{2}");
     plotPFu1frac2.AddGraph(grPFu1frac2,"",kBlack,kOpenCircle);
@@ -442,75 +556,109 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   
   if(pfu1model>=3) { 
     grPFu1mean3 = new TGraphErrors(nbins,xval,pfu1Mean3,xerr,pfu1Mean3Err);
+    grPFu1mean3->GetYaxis()->SetRangeUser(-350., 20.);
+    //    grPFu1mean3->GetYaxis()->SetRangeUser(0., 2.);
     grPFu1mean3->SetName("grPFu1mean3");
-    CPlot plotPFu1mean3("pfu1mean3","","p_{T}(ll) [GeV/c]","#mu(u_{1}) [GeV]");
-    plotPFu1mean3.AddGraph(grPFu1mean3,"");
+    fitresPFu1mean3 = grPFu1mean3->Fit("fcnPFu1mean3","QMRN0FBSE");
+    sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu1mean3->GetChisquare())/(fcnPFu1mean3->GetNDF()));
+    CPlot plotPFu1mean3("pfu1mean3","","p_{T}(ll) [GeV/c]","#mu(u_{#parallel}) [GeV]");
     plotPFu1mean3.AddGraph(grPFu1mean3,"",kBlack,kOpenCircle);
+    plotPFu1mean3.AddFcn(fcnPFu1mean3,kRed);
     plotPFu1mean3.AddTextBox(chi2ndf,0.65,0.87,0.95,0.82,0,kBlack,-1);
+    sprintf(fitparam,"p_{0} = %.3f #pm %.3f",fcnPFu1mean3->GetParameter(0),fcnPFu1mean3->GetParError(0)); plotPFu1mean3.AddTextBox(fitparam,0.65,0.80,0.95,0.75,0,kBlack,-1);
+    sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu1mean3->GetParameter(1),fcnPFu1mean3->GetParError(1)); plotPFu1mean3.AddTextBox(fitparam,0.65,0.75,0.95,0.70,0,kBlack,-1);
+    sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu1mean3->GetParameter(2),fcnPFu1mean3->GetParError(2)); plotPFu1mean3.AddTextBox(fitparam,0.65,0.70,0.95,0.65,0,kBlack,-1);
+    latexLabel.DrawLatex(0.20, 0.8, label);
     plotPFu1mean3.Draw(c,kTRUE,"png");
     
     grPFu1sigma3 = new TGraphErrors(nbins,xval,pfu1Sigma3,xerr,pfu1Sigma3Err);
+    grPFu1sigma3->GetYaxis()->SetRangeUser(0., 150.);
     grPFu1sigma3->SetName("grPFu1sigma3");
-    CPlot plotPFu1sigma3("pfu1sigma3","","p_{T}(ll) [GeV/c]","#sigma_{3} [GeV]");
+    CPlot plotPFu1sigma3("pfu1sigma3","","p_{T}(ll) [GeV/c]","#sigma_{3}(u_{#parallel}) [GeV]");
     plotPFu1sigma3.AddGraph(grPFu1sigma3,"",kBlack,kOpenCircle);
+    latexLabel.DrawLatex(0.20, 0.2, label);
     plotPFu1sigma3.Draw(c,kTRUE,"png");
   
     grPFu1frac3 = new TGraphErrors(nbins,xval,pfu1Frac3, xerr,pfu1Frac3Err);
+    grPFu1frac3->GetYaxis()->SetRangeUser(0., 1.);
     grPFu1frac3->SetName("grPFu1frac3");
     CPlot plotPFu1frac3("pfu1frac3","","p_{T}(ll) [GeV/c]","f_{3}");
     plotPFu1frac3.AddGraph(grPFu1frac3,"",kBlack,kOpenCircle);
     plotPFu1frac3.Draw(c,kTRUE,"png");
   }
 
+  // adding chi2
+  grPFu1chi2 = new TGraphErrors(nbins,xval,pfu1chi2,xerr,pfu1chi2Err);
+  grPFu1chi2 ->GetYaxis()->SetRangeUser(0., 10.);
+  grPFu1chi2 ->SetName("grPFu1chi2");
+  CPlot plotPFu1chi2("pfu1chi2","","p_{T}(ll) [GeV/c]","#chi^{2}(u_{#parallel}) [GeV]");
+  plotPFu1chi2.AddGraph(grPFu1chi2,"",kBlack,kOpenCircle);
+  latexLabel.DrawLatex(0.20, 0.8, label);
+  plotPFu1chi2.Draw(c,kTRUE,"png");
+
   //
   // Plotting PF-MET u2 vs. dilepton pT
   //
   grPFu2mean = new TGraphErrors(nbins,xval,pfu2Mean,xerr,pfu2MeanErr);
+  grPFu2mean->GetYaxis()->SetRangeUser(-20, 20.);
   grPFu2mean->SetName("grPFu2mean");
-  CPlot plotPFu2mean("pfu2mean","","p_{T}(ll) [GeV/c]","#mu(u_{2}) [GeV]");
-  plotPFu2mean.AddGraph(grPFu2mean,"");
+  CPlot plotPFu2mean("pfu2mean","","p_{T}(ll) [GeV/c]","#mu(u_{#perp}) [GeV]");
   plotPFu2mean.AddGraph(grPFu2mean,"",kBlack,kOpenCircle);
-  plotPFu2mean.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+  //  plotPFu2mean.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
   plotPFu2mean.Draw(c,kTRUE,"png");
 
   
   grPFu2sigma1 = new TGraphErrors(nbins,xval,pfu2Sigma1,xerr,pfu2Sigma1Err);
+  grPFu2sigma1->GetYaxis()->SetRangeUser(0., 30.);
   grPFu2sigma1->SetName("grPFu2sigma1");
-  CPlot plotPFu2sigma1("pfu2sigma1","","p_{T}(ll) [GeV/c]","#sigma_{1}(u_{2}) [GeV]");
-  plotPFu2sigma1.AddGraph(grPFu2sigma1,"");
+  //  fitresPFu2sigma1 = grPFu2sigma1->Fit("fcnPFu2sigma1","QMRN0SE");
+  //  sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu2sigma1->GetChisquare())/(fcnPFu2sigma1->GetNDF()));
+  CPlot plotPFu2sigma1("pfu2sigma1","","p_{T}(ll) [GeV/c]","#sigma_{1}(u_{#perp}  ) [GeV]");
   plotPFu2sigma1.AddGraph(grPFu2sigma1,"",kBlack,kOpenCircle);
-  plotPFu2sigma1.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+  //  plotPFu2sigma1.AddFcn(fcnPFu2sigma1,kRed);
+  //  sprintf(fitparam,"p_{0} = %.1f #pm %.1f",fcnPFu2sigma1->GetParameter(0),fcnPFu2sigma1->GetParError(0)); plotPFu2sigma1.AddTextBox(fitparam,0.21,0.80,0.51,0.75,0,kBlack,-1);
+  //  sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu2sigma1->GetParameter(1),fcnPFu2sigma1->GetParError(1)); plotPFu2sigma1.AddTextBox(fitparam,0.21,0.75,0.51,0.70,0,kBlack,-1);
+  //  sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu2sigma1->GetParameter(2),fcnPFu2sigma1->GetParError(2)); plotPFu2sigma1.AddTextBox(fitparam,0.21,0.70,0.51,0.65,0,kBlack,-1);
+  //  plotPFu2sigma1.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+  latexLabel.DrawLatex(0.20, 0.2, label);
   plotPFu2sigma1.Draw(c,kTRUE,"png");
 
   if(pfu2model>=2) {
     
     grPFu2mean2 = new TGraphErrors(nbins,xval,pfu2Mean2,xerr,pfu2Mean2Err);
+    grPFu2mean2->GetYaxis()->SetRangeUser(-20, 20.);
     grPFu2mean2->SetName("grPFu2mean2");
-    CPlot plotPFu2mean2("pfu2mean2","","p_{T}(ll) [GeV/c]","#mu(u_{2}) [GeV]");
-    plotPFu2mean2.AddGraph(grPFu2mean2,"");
+    CPlot plotPFu2mean2("pfu2mean2","","p_{T}(ll) [GeV/c]","#mu(u_{#perp}  ) [GeV]");
     plotPFu2mean2.AddGraph(grPFu2mean2,"",kBlack,kOpenCircle);
     plotPFu2mean2.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
     plotPFu2mean2.Draw(c,kTRUE,"png");
     
     grPFu2sigma2 = new TGraphErrors(nbins,xval,pfu2Sigma2,xerr,pfu2Sigma2Err);
+    grPFu2sigma2->GetYaxis()->SetRangeUser(0., 30.);
     grPFu2sigma2->SetName("grPFu2sigma2");
-    CPlot plotPFu2sigma2("pfu2sigma2","","p_{T}(ll) [GeV/c]","#sigma_{2}(u_{2}) [GeV]");    
-    plotPFu2sigma2.AddGraph(grPFu2sigma2,"");
+    //    fitresPFu2sigma2 = grPFu2sigma2->Fit("fcnPFu2sigma1","QMRN0SE");
+    //    sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu2sigma2->GetChisquare())/(fcnPFu2sigma2->GetNDF()));
+    CPlot plotPFu2sigma2("pfu2sigma2","","p_{T}(ll) [GeV/c]","#sigma_{2}(u_{#perp}  ) [GeV]");
     plotPFu2sigma2.AddGraph(grPFu2sigma2,"",kBlack,kOpenCircle);
-    plotPFu2sigma2.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    //    plotPFu2sigma2.AddFcn(fcnPFu2sigma2,kRed);
+    //    sprintf(fitparam,"p_{0} = %.1f #pm %.1f",fcnPFu2sigma2->GetParameter(0),fcnPFu2sigma2->GetParError(0)); plotPFu2sigma2.AddTextBox(fitparam,0.21,0.80,0.51,0.75,0,kBlack,-1);
+    //    sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu2sigma2->GetParameter(1),fcnPFu2sigma2->GetParError(1)); plotPFu2sigma2.AddTextBox(fitparam,0.21,0.75,0.51,0.70,0,kBlack,-1);
+    //    sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu2sigma2->GetParameter(2),fcnPFu2sigma2->GetParError(2)); plotPFu2sigma2.AddTextBox(fitparam,0.21,0.70,0.51,0.65,0,kBlack,-1);
+    //    plotPFu2sigma2.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    latexLabel.DrawLatex(0.20, 0.2, label);
     plotPFu2sigma2.Draw(c,kTRUE,"png");
 
 
     grPFu2sigma0 = new TGraphErrors(nbins,xval,pfu2Sigma0,xerr,pfu2Sigma0Err);
     grPFu2sigma0->SetName("grPFu2sigma0");
-    CPlot plotPFu2sigma0("pfu2sigma0","","p_{T}(ll) [GeV/c]","#sigma(u_{2}) [GeV]");
-    plotPFu2sigma0.AddGraph(grPFu2sigma0,"");
+    CPlot plotPFu2sigma0("pfu2sigma0","","p_{T}(ll) [GeV/c]","#sigma(u_{#perp}  ) [GeV]");
     plotPFu2sigma0.AddGraph(grPFu2sigma0,"",kBlack,kOpenCircle);
-    plotPFu2sigma0.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    //    plotPFu2sigma0.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
     plotPFu2sigma0.Draw(c,kTRUE,"png");
 
     
     grPFu2frac2 = new TGraphErrors(nbins,xval,pfu2Frac2, xerr,pfu2Frac2Err);
+    grPFu1frac2->GetYaxis()->SetRangeUser(0., 1.);
     grPFu2frac2->SetName("grPFu2frac2");
     CPlot plotPFu2frac2("pfu2frac2","","p_{T}(ll) [GeV/c]","f_{2}");
     plotPFu2frac2.AddGraph(grPFu2frac2,"",kBlack,kOpenCircle);
@@ -520,32 +668,51 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   if(pfu2model>=3) {  
     
     grPFu2mean3 = new TGraphErrors(nbins,xval,pfu2Mean3,xerr,pfu2Mean3Err);
+    grPFu2mean3->GetYaxis()->SetRangeUser(-20, 20.);
     grPFu2mean3->SetName("grPFu2mean3");
-    CPlot plotPFu2mean3("pfu2mean2","","p_{T}(ll) [GeV/c]","#mu(u_{2}) [GeV]");
-    plotPFu2mean3.AddGraph(grPFu2mean3,"");
+    CPlot plotPFu2mean3("pfu2mean3","","p_{T}(ll) [GeV/c]","#mu(u_{#perp}  ) [GeV]");
     plotPFu2mean3.AddGraph(grPFu2mean3,"",kBlack,kOpenCircle);
     plotPFu2mean3.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
     plotPFu2mean3.Draw(c,kTRUE,"png");
     
     grPFu2sigma3 = new TGraphErrors(nbins,xval,pfu2Sigma3,xerr,pfu2Sigma3Err);
+    grPFu2sigma3->GetYaxis()->SetRangeUser(0., 150.);
     grPFu2sigma3->SetName("grPFu2sigma3");
-    CPlot plotPFu2sigma3("pfu2sigma3","","p_{T}(ll) [GeV/c]","#sigma_{3} [GeV]");
+    //    fitresPFu2sigma3 = grPFu2sigma3->Fit("fcnPFu2sigma1","QMRN0SE");
+    //    sprintf(chi2ndf,"#chi^{2}/ndf = %.2f",(fcnPFu2sigma3->GetChisquare())/(fcnPFu2sigma3->GetNDF()));
+    CPlot plotPFu2sigma3("pfu2sigma3","","p_{T}(ll) [GeV/c]","#sigma_{3} (u_{#perp}  ) [GeV]");
     plotPFu2sigma3.AddGraph(grPFu2sigma3,"",kBlack,kOpenCircle);
+    //    plotPFu2sigma3.AddFcn(fcnPFu2sigma3,kRed);
+    //    sprintf(fitparam,"p_{0} = (%.1f #pm %.1f) #times 10^{-5}",fcnPFu2sigma3->GetParameter(0),fcnPFu2sigma3->GetParError(0)); plotPFu2sigma3.AddTextBox(fitparam,0.21,0.80,0.51,0.75,0,kBlack,-1);
+    //    sprintf(fitparam,"p_{1} = %.3f #pm %.3f",fcnPFu2sigma3->GetParameter(1),fcnPFu2sigma3->GetParError(1)); plotPFu2sigma3.AddTextBox(fitparam,0.21,0.75,0.51,0.70,0,kBlack,-1);
+    //    sprintf(fitparam,"p_{2} = %.3f #pm %.3f",fcnPFu2sigma3->GetParameter(2),fcnPFu2sigma3->GetParError(2)); plotPFu2sigma3.AddTextBox(fitparam,0.21,0.70,0.51,0.65,0,kBlack,-1);
+    //    plotPFu2sigma3.AddTextBox(chi2ndf,0.21,0.87,0.41,0.82,0,kBlack,-1);
+    latexLabel.DrawLatex(0.20, 0.2, label);
     plotPFu2sigma3.Draw(c,kTRUE,"png");
   
     grPFu2frac3 = new TGraphErrors(nbins,xval,pfu2Frac3, xerr,pfu2Frac3Err);
+    grPFu2frac3->GetYaxis()->SetRangeUser(0., 1.);
     grPFu2frac3->SetName("grPFu2frac3");
     CPlot plotPFu2frac3("pfu2frac3","","p_{T}(ll) [GeV/c]","f_{3}");
     plotPFu2frac3.AddGraph(grPFu2frac3,"",kBlack,kOpenCircle);
     plotPFu2frac3.Draw(c,kTRUE,"png");
   }
 
+  // adding chi2
+  grPFu2chi2 = new TGraphErrors(nbins,xval,pfu2chi2,xerr,pfu2chi2Err);
+  grPFu2chi2 ->GetYaxis()->SetRangeUser(0., 10.);
+  grPFu2chi2 ->SetName("grPFu2chi2");
+  CPlot plotPFu2chi2("pfu2chi2","","p_{T}(ll) [GeV/c]","#chi^{2}(u_{#perp} ) [GeV]");
+  plotPFu2chi2.AddGraph(grPFu2chi2,"",kBlack,kOpenCircle);
+  latexLabel.DrawLatex(0.20, 0.8, label);
+  plotPFu2chi2.Draw(c,kTRUE,"png");
+
   delete infile;
   infile=0, intree=0;
 
   TH1D *hCorrPFu1u2 = new TH1D("hCorrPFu1u2","",ncorrbins,corrbins);
   for(Int_t ibin=0; ibin<ncorrbins; ibin++) { hCorrPFu1u2->SetBinContent(ibin+1,hPFu1u2v[ibin]->GetCorrelationFactor()); }
-  CPlot plotCorrPFu1u2("corrpfu1u2","","p_{T}(ll) [GeV/c]","corr(PF u_{1}, PF u_{2})");
+  CPlot plotCorrPFu1u2("corrpfu1u2","","p_{T}(ll) [GeV/c]","corr(PF u_{#parallel}, PF u_{#perp})");
   plotCorrPFu1u2.AddHist1D(hCorrPFu1u2,"");
   plotCorrPFu1u2.Draw(c,kTRUE,"png");
   
@@ -559,24 +726,26 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   TFile *outfile = new TFile(outfname,"RECREATE");
   
   if(grPFu1mean)    grPFu1mean->Write();
-  if(grPFu1mean2)    grPFu1mean2->Write();
-  if(grPFu1mean3)    grPFu1mean3->Write();
+  if(grPFu1mean2)   grPFu1mean2->Write();
+  if(grPFu1mean3)   grPFu1mean3->Write();
   if(grPFu1sigma0)  grPFu1sigma0->Write();
   if(grPFu1sigma1)  grPFu1sigma1->Write();
   if(grPFu1sigma2)  grPFu1sigma2->Write();
   if(grPFu1sigma3)  grPFu1sigma3->Write();
   if(grPFu1frac2)   grPFu1frac2->Write();
   if(grPFu1frac3)   grPFu1frac3->Write();
+  if(grPFu1chi2)    grPFu1chi2->Write();
 
   if(grPFu2mean)    grPFu2mean->Write();
-  if(grPFu2mean2)    grPFu2mean2->Write();
-  if(grPFu2mean3)    grPFu2mean3->Write();
+  if(grPFu2mean2)   grPFu2mean2->Write();
+  if(grPFu2mean3)   grPFu2mean3->Write();
   if(grPFu2sigma0)  grPFu2sigma0->Write();
   if(grPFu2sigma1)  grPFu2sigma1->Write();
   if(grPFu2sigma2)  grPFu2sigma2->Write();
   if(grPFu2sigma3)  grPFu2sigma3->Write();
   if(grPFu2frac2)   grPFu2frac2->Write();
   if(grPFu2frac3)   grPFu2frac3->Write();
+  if(grPFu2chi2)    grPFu2chi2->Write();
   
   hCorrPFu1u2->Write();
     
@@ -588,6 +757,8 @@ void fitRecoilZmm(TString infilename="/data/blue/Bacon/Run2/wz_flat/Zmumu/ntuple
   cout << endl;
   cout << "  <> Output saved in " << outputDir << "/" << endl;    
   cout << endl;
+
+  return;
 }
 
 
@@ -813,26 +984,33 @@ void makeHTML(const TString outDir,  const Int_t nbins,
   htmlfile << "</body>" << endl;
   htmlfile << "</html>" << endl;
   htmlfile.close(); 
+
+  return;
+
 }
 
 //--------------------------------------------------------------------------------------------------
 void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_t *ptbins, const Int_t nbins,
                 const Int_t model, const Bool_t sigOnly,
+		vector<RooDataSet> lDataSet, vector<RooRealVar> lVar,
                 TCanvas *c, const char *plabel, const char *xlabel,
 		Double_t *mean1Arr,   Double_t *mean1ErrArr,
-        Double_t *mean2Arr,   Double_t *mean2ErrArr,
-        Double_t *mean3Arr,   Double_t *mean3ErrArr,
+		Double_t *mean2Arr,   Double_t *mean2ErrArr,
+		Double_t *mean3Arr,   Double_t *mean3ErrArr,
 		Double_t *sigma0Arr, Double_t *sigma0ErrArr,
 		Double_t *sigma1Arr, Double_t *sigma1ErrArr,
 		Double_t *sigma2Arr, Double_t *sigma2ErrArr,
 		Double_t *sigma3Arr, Double_t *sigma3ErrArr,
 		Double_t *frac2Arr,  Double_t *frac2ErrArr,
 		Double_t *frac3Arr,  Double_t *frac3ErrArr,
-        RooWorkspace *wksp
+		Double_t *chi2Arr,   Double_t *chi2ErrArr,
+		RooWorkspace *wksp,
+		int etaBinCategory
 ) {
   char pname[50];
   char ylabel[50];
   char binlabel[50];
+  char binYlabel[50];
   char nsigtext[50];
   char nbkgtext[50];
   
@@ -844,6 +1022,25 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
   char sig2text[50];
   char sig3text[50];
   
+  /*
+  const double ydiv = 0.25;
+  TPad *pad1 = new TPad("pad1", "",0.05,ydiv,1,1);
+  pad1->SetTickx(1);
+  pad1->SetTicky(1);
+  pad1->SetBottomMargin(0);
+  pad1->SetTopMargin(0.075);
+  pad1->Draw();
+
+  TPad *pad2 = new TPad("pad2", "",0.05,0,1,ydiv);
+  //  pad2->SetLogx(logx);
+  pad2->SetTickx(1);
+  pad2->SetTicky(1);
+  pad2->SetTopMargin(0);
+  pad2->SetBottomMargin(0.35);
+  pad2->Draw();
+  */
+
+
   for(Int_t ibin=0; ibin<nbins; ibin++) {
     
     std::stringstream name;
@@ -852,43 +1049,60 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     RooRealVar u(name.str().c_str(),name.str().c_str(),hv[ibin]->GetXaxis()->GetXmin(),hv[ibin]->GetXaxis()->GetXmax());name.str(""); 
     u.setBins(100);
     RooDataHist dataHist("dataHist","dataHist",RooArgSet(u),hv[ibin]);
-    
+
     //
     // Set up background histogram templates
     //
     RooDataHist bkgHist("bkgHist","bkgHist",RooArgSet(u),hbkgv[ibin]);
-    RooHistPdf bkg("bkg","bkg",u,bkgHist,0);
-    
+    //    RooHistPdf bkg("bkg","bkg",u,bkgHist,0);
+    name.str("");  name << "bkg_" << ibin << std::endl;
+    RooHistPdf bkg(name.str().c_str(),name.str().c_str(),u,bkgHist,0);name.str("");
+
     //
     // Set up fit parameters
     //
     name.str(""); name << "mean1_" << ibin;
     RooRealVar mean1(name.str().c_str(),name.str().c_str(),
-                    hv[ibin]->GetMean()*0.95,
-                    hv[ibin]->GetXaxis()->GetXmin(),
-                    hv[ibin]->GetXaxis()->GetXmax());
-    name.str(""); name << "mean2_" << ibin;
-    RooRealVar mean2(name.str().c_str(),name.str().c_str(),
                     hv[ibin]->GetMean(),
                     hv[ibin]->GetXaxis()->GetXmin()+50,
                     hv[ibin]->GetXaxis()->GetXmax()-50);
+    name.str(""); name << "mean2_" << ibin;
+    RooRealVar mean2(name.str().c_str(),name.str().c_str(),
+		     hv[ibin]->GetMean(),
+		     hv[ibin]->GetXaxis()->GetXmin()+50,
+		     hv[ibin]->GetXaxis()->GetXmax()-50);
     name.str(""); name << "mean3_" << ibin;
     RooRealVar mean3(name.str().c_str(),name.str().c_str(),
-                    hv[ibin]->GetMean()*1.0,
-                    hv[ibin]->GetXaxis()->GetXmin()+50,
-                    hv[ibin]->GetXaxis()->GetXmax()-50);
+		      hv[ibin]->GetMean()*0.85,
+		      hv[ibin]->GetXaxis()->GetXmin()+50,
+		      hv[ibin]->GetXaxis()->GetXmax()-50);
+    //    RooRealVar mean3f(name.str().c_str(),name.str().c_str(),
+    //		     0.85,
+    //		     0.6,
+    //		     1.1);
+
+    //    RooFormulaVar * mean3= new RooFormulaVar("meanFrac","@0 * @1",RooArgSet(mean1,mean3f));
+
     name.str(""); name << "sigma1_" << ibin;
-    RooRealVar sigma1(name.str().c_str(),name.str().c_str(),0.3*(hv[ibin]->GetRMS()),0,1.5*(hv[ibin]->GetRMS()));
+    RooRealVar sigma1(name.str().c_str(),name.str().c_str(),0.3*(hv[ibin]->GetRMS()),0,2.3*(hv[ibin]->GetRMS()));
     name.str(""); name << "sigma2_" << ibin;
-    RooRealVar sigma2(name.str().c_str(),name.str().c_str(),1.3*(hv[ibin]->GetRMS()),0,2.0*(hv[ibin]->GetRMS()));
+    RooRealVar sigma2(name.str().c_str(),name.str().c_str(),1.0*(hv[ibin]->GetRMS()),0.,4.5*(hv[ibin]->GetRMS()));
     name.str(""); name << "sigma3_" << ibin;
-    RooRealVar sigma3(name.str().c_str(),name.str().c_str(),3.0*(hv[ibin]->GetRMS()),0,5*(hv[ibin]->GetRMS())); 
+    RooRealVar sigma3(name.str().c_str(),name.str().c_str(),2.0*(hv[ibin]->GetRMS()),0,9*hv[ibin]->GetRMS());
+    //    RooRealVar sigma3(name.str().c_str(),name.str().c_str(),2.0*(hv[ibin]->GetRMS()),10 ,std::min(int(9*hv[ibin]->GetRMS()),100));
     name.str(""); name << "frac2_" << ibin;
     RooRealVar frac2(name.str().c_str(),name.str().c_str(),0.5,0.15,0.85);
     name.str(""); name << "frac3_" << ibin;
     RooRealVar frac3(name.str().c_str(),name.str().c_str(),0.05,0,0.15);
-    
-    
+
+    if(string(plabel)==string("pfu2")) {
+
+      mean1.setVal(0); mean1.setConstant(kTRUE);
+      mean2.setVal(0); mean2.setConstant(kTRUE);
+      mean3.setVal(0); mean3.setConstant(kTRUE);
+
+    }
+
     name.str(""); name << "gauss1_" << ibin;
     RooGaussian gauss1(name.str().c_str(),name.str().c_str(),u,mean1,sigma1);
     name.str(""); name << "gauss2_" << ibin;
@@ -932,6 +1146,8 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     
     
     if(ibin>0) {
+      /* // stephanie settings
+
       mean1.setVal(hv[ibin]->GetMean());
       mean2.setVal(hv[ibin]->GetMean());
       mean3.setVal(hv[ibin]->GetMean());
@@ -945,7 +1161,8 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
       sigma3.setMin(0.0*(hv[ibin]->GetRMS()));
       sigma3.setMax(5.0*(hv[ibin]->GetRMS()));
       sigma3.setVal(1.5*(hv[ibin-1]->GetRMS()));
-      
+      */
+
 //       if(ibin==1||ibin==24||ibin==36||ibin==37||ibin==40||ibin==52||ibin==33/* || ibin==40*/){
 //         mean1.setVal(hv[ibin]->GetMean());
 //         mean2.setVal(hv[ibin]->GetMean());
@@ -1001,6 +1218,7 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     //
     char formula[100];
     RooArgList params;
+    /*
     if(model==1) {
       sprintf(formula,"sigma1");
     
@@ -1018,6 +1236,7 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
       params.add(sigma2);
       params.add(sigma3);
     }
+*/
     RooFormulaVar sigma0("sigma0",formula,params);
     
     std::cout << "blah" << std::endl;
@@ -1043,13 +1262,26 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     
     
     RooArgList yields;
+
     name.str(""); name << "nsig_" << ibin;
-    RooRealVar nsig(name.str().c_str(),name.str().c_str(),0.98*(hv[ibin]->Integral()),0.,hv[ibin]->Integral());
-    yields.add(nsig);
+    //    RooRealVar nsig(name.str().c_str(),name.str().c_str(),0.98*(hv[ibin]->Integral()),0.,hv[ibin]->Integral());
+    RooRealVar nsig(name.str().c_str(),name.str().c_str(),0.98*(hv[ibin]->Integral()),0.,1.1*hv[ibin]->Integral()); // just to be sure that doesn't it the boundary
     name.str(""); name << "nbkg_" << ibin;
-    RooRealVar nbkg(name.str().c_str(),name.str().c_str(),0.01*(hv[ibin]->Integral()),0.,0.50*(hv[ibin]->Integral()));
-    if(!sigOnly) yields.add(nbkg);
-    else         nbkg.setVal(0);
+    RooRealVar nbkg(name.str().c_str(),name.str().c_str(),0.01*(hv[ibin]->Integral()),0.,0.25*(hv[ibin]->Integral()));
+
+    RooRealVar *lAbkgFrac =new RooRealVar("AbkgFrac","AbkgFrac",0.98,0.95,0.999);
+
+    if(sigOnly) {
+      yields.add(nsig);
+      nbkg.setVal(0);
+      //      if(!sigOnly) yields.add(nbkg);
+      //      else         nbkg.setVal(0);
+
+    } else {
+      RooFormulaVar * sigbkgFrac= new RooFormulaVar("bkgfrac","@0",RooArgSet(*lAbkgFrac));
+      yields.add(*sigbkgFrac);
+    }
+
     
 //     std::stringstream name;
     name.str("");  name << "modelpdf_" << ibin << std::endl;
@@ -1058,7 +1290,7 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     std::cout << "name = " << name.str().c_str() << std::endl;
     
     std::cout << "on bin # " << ibin << std::endl;
-    std::cout << "signal evts = " << nsig.getVal() << std::endl;
+    if(sigOnly) std::cout << "signal evts = " << nsig.getVal() << std::endl;
     std::cout << "total events = " << hv[ibin]->Integral() << std::endl;
     std::cout << "sigma1 = " << sigma1.getVal() << std::endl;
     std::cout << "sigma2 = " << sigma2.getVal() << std::endl;
@@ -1068,16 +1300,35 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     //
     // Perform fit
     //
+
+    //    ROOT::Math::MinimizerOptions::SetDefaultMaxIterations(1000000);
+
     RooFitResult *fitResult=0;
     fitResult = modelpdf.fitTo(dataHist,
+			       NumCPU(4),
+			       Minimizer("Minuit2","minimize"),
 			       RooFit::Strategy(2),
 	                       RooFit::Save());
-    if(frac2.getVal() + frac3.getVal() > 1.0) std::cout << "WRONG NORMALIZATION??? " << std::endl;
-    
-    if(frac2.getVal() + frac3.getVal() > 1.0) std::cout << "WRONG NORMALIZATION??? " << std::endl;
-    
+
+    if(fitResult->status()>1) {
+
+      fitResult = modelpdf.fitTo(dataHist,
+				 NumCPU(4),
+				 Minimizer("Minuit2","scan"),
+				 RooFit::Strategy(2),
+				 RooFit::Save());
+    }
+
+    c->SetFillColor(kWhite);
+    if(fitResult->status()>1) c->SetFillColor(kYellow);
+
+    //    if(frac2.getVal() + frac3.getVal() > 1.0) std::cout << "WRONG NORMALIZATION??? " << std::endl;
+    //    if(frac2.getVal() + frac3.getVal() > 1.0) std::cout << "WRONG NORMALIZATION??? " << std::endl;
+
     wksp->import(u);
     wksp->import(modelpdf);
+    wksp->import(sig);
+    wksp->import(bkg);
     
     mean1Arr[ibin]      = mean1.getVal();
     mean1ErrArr[ibin]   = mean1.getError();
@@ -1101,7 +1352,7 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
       frac3Arr[ibin]     = frac3.getVal();
       frac3ErrArr[ibin]  = frac3.getError();
     }
-    
+
     std::cout << "Plot Fit results " << std::endl;
     //
     // Plot fit results
@@ -1109,50 +1360,137 @@ void performFit(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_
     RooPlot *frame = u.frame(Bins(100));
     dataHist.plotOn(frame,MarkerStyle(kFullCircle),MarkerSize(0.8),DrawOption("ZP"));
     modelpdf.plotOn(frame);
-    if(!sigOnly) modelpdf.plotOn(frame,Components("bkg"),LineStyle(kDotted),LineColor(kMagenta+2));
+
+    name.str(""); name << "bkg_" << ibin ;
+    if(!sigOnly) modelpdf.plotOn(frame,Components(bkg),FillColor(kRed), DrawOption("F"));
     name.str(""); name << "gauss1_" << ibin ;
     if(model>=2) sig.plotOn(frame,Components(name.str().c_str()),LineStyle(kDashed),LineColor(kRed));
     name.str(""); name << "gauss2_" << ibin ;
-    if(model>=2) sig.plotOn(frame,Components(name.str().c_str()),LineStyle(kDashed),LineColor(kCyan+2));
+    if(model>=2) sig.plotOn(frame,Components(name.str().c_str()),LineStyle(kDashed),LineColor(kMagenta));
     name.str(""); name << "gauss3_" << ibin ;
     if(model>=3) sig.plotOn(frame,Components(name.str().c_str()),LineStyle(kDashed),LineColor(kGreen+2));
+    name.str(""); name << "bkg_" << ibin ;
+
+    // draw the curve
+    if(!sigOnly) modelpdf.plotOn(frame,FillColor(kGray),VisualizeError(*fitResult,1),RooFit::Components(modelpdf)); // 1 sigma band
+    if(!sigOnly) modelpdf.plotOn(frame,RooFit::LineColor(kGray+2));
+    sig.plotOn(frame,FillColor(7),VisualizeError(*fitResult,1),RooFit::Components(sig)); // 1 sigma band
+    sig.plotOn(frame,RooFit::LineColor(kBlue));
     
+    // redraw the data
+    dataHist.plotOn(frame,MarkerStyle(kFullCircle),MarkerSize(0.8),DrawOption("ZP"));
+
+    if(do_keys) {
+
+      //      lDataSet[ibin].Print();
+      name.str(""); name << "key_" << ibin;
+      //      RooKeysPdf * pdf_keys = new RooKeysPdf(name.str().c_str(),name.str().c_str(), u, dataHist, RooKeysPdf::NoMirror, 2);
+      RooKeysPdf pdf_keys(name.str().c_str(),name.str().c_str(),lVar[ibin], lDataSet[ibin], RooKeysPdf::NoMirror, 2);
+
+
+      RooPlot* xframe  = lVar[ibin].frame(Title(Form("%s Zp_{T}=%d",plabel,ibin))) ;
+      lDataSet[ibin].plotOn(xframe) ;
+      TCanvas* c = new TCanvas("validatePDF","validatePDF",800,400) ;
+      c->cd();
+      pdf_keys.plotOn(xframe,LineColor(kBlue)) ;
+      xframe->Draw() ;
+
+      c->SaveAs(Form("%s_%d_dataset.png",plabel,ibin));
+
+      name.str("");
+
+      //      wksp->import(lDataSet[ibin]);
+      wksp->import(pdf_keys);
+      //      wksp->import(lVar[ibin],RooFit::RecycleConflictNodes(),RooFit::Silence());
+      //      wksp->import(pdf_keys,RooFit::RecycleConflictNodes(),RooFit::Silence());
+
+      wksp->Print();
+
+    }
+
+
+    int sizeParam=0;
+    if(string(plabel)==string("pfu1")) sizeParam=8; // 3 means + 3 sigma + 2 frac
+    if(string(plabel)==string("pfu2")) sizeParam=5; // 0 means + 3 sigma + 2 frac
+    //    frame->Print();
+    /*
+    frame_u_11_674e5e0[u_11] = (RooHist::h_dataHist,RooCurve::modelpdf_11
+    _Norm[u_11],RooCurve::sig_11_Norm[u_11]_Comp[gauss1_11],RooCurve::sig_11_Norm[u_11]_Comp[gauss2_11],RooCurve::sig_11_Norm[u_11]_Comp[gauss3_11],RooCurve::sig_11_Norm[u_11]_errorband_Comp[sig_11],RooCurve::sig_11_Norm[u_11],RooHist::h_dataHist)
+    */
+    TString nameRooHist=Form("h_%s",dataHist.GetName());
+    TString nameRooCurve=Form("sig_%d_Norm[u_%d]",ibin,ibin);
+    chi2Arr[ibin]  = frame->chiSquare(nameRooCurve.Data(),nameRooHist.Data(),sizeParam);
+    chi2ErrArr[ibin]  = 0 ;
+    if(chi2Arr[ibin] > 10) { chi2Arr[ibin]=0; chi2ErrArr[ibin]=200; } // just a larger number so that is easy to notice on the plot
+    //    cout << " chi2Arr[ibin]=" << chi2Arr[ibin] << " chi2ErrArr[ibin]=" << chi2ErrArr[ibin] << endl;
+
     sprintf(pname,"%sfit_%i",plabel,ibin);
     sprintf(ylabel,"Events / %.1f GeV",hv[ibin]->GetBinWidth(1));
     sprintf(binlabel,"%i < p_{T} < %i",(Int_t)ptbins[ibin],(Int_t)ptbins[ibin+1]);    
+
+    if(etaBinCategory==1) sprintf(binYlabel,"|y| < 0.5");
+    if(etaBinCategory==2) sprintf(binYlabel,"0.5 < |y| < 1");
+    if(etaBinCategory==3) sprintf(binYlabel,"|y| > 1");
+
     if(sigOnly) {
       sprintf(nsigtext,"N_{evts} = %i",(Int_t)hv[ibin]->Integral());
     } else {
-      sprintf(nsigtext,"N_{sig} = %.1f #pm %.1f",nsig.getVal(),nsig.getError());
-      sprintf(nbkgtext,"N_{bkg} = %.1f #pm %.1f",nbkg.getVal(),nbkg.getError());
+      sprintf(nsigtext,"N_{sig}/(N_{bkg}+N_{sig}) = %.3f #pm %.3f",lAbkgFrac->getVal(),lAbkgFrac->getError());
+      //      sprintf(nsigtext,"N_{sig} = %.1f #pm %.1f",nsig.getVal(),nsig.getError());
+      //      sprintf(nbkgtext,"N_{bkg} = %.1f #pm %.1f",nbkg.getVal(),nbkg.getError());
     }
     sprintf(mean1text,"#mu_{1} = %.1f #pm %.1f",mean1Arr[ibin],mean1ErrArr[ibin]);
     sprintf(sig1text,"#sigma = %.1f #pm %.1f",sigma1Arr[ibin],sigma1ErrArr[ibin]);
     if(model>=2) {
       sprintf(mean2text,"#mu_{2} = %.1f #pm %.1f",mean2Arr[ibin],mean2ErrArr[ibin]);
+      //      sprintf(mean2text,"#mu_{2} = #mu_{1} ");
       sprintf(sig0text,"#sigma = %.1f #pm %.1f",sigma0Arr[ibin],sigma0ErrArr[ibin]);
       sprintf(sig1text,"#sigma_{1} = %.1f #pm %.1f",sigma1Arr[ibin],sigma1ErrArr[ibin]);          
       sprintf(sig2text,"#sigma_{2} = %.1f #pm %.1f",sigma2Arr[ibin],sigma2ErrArr[ibin]);
     }
-    if(model>3){
+    if(model>=3){
       sprintf(mean3text,"#mu_{3} = %.1f #pm %.1f",mean3Arr[ibin],mean3ErrArr[ibin]);
       sprintf(sig3text,"#sigma_{3} = %.1f #pm %.1f",sigma3Arr[ibin],sigma3ErrArr[ibin]);
     }
     
     CPlot plot(pname,frame,"",xlabel,ylabel);
+    //    pad1->cd();
     plot.AddTextBox(binlabel,0.21,0.80,0.51,0.85,0,kBlack,-1);
+    if(etaBinCategory!=0) plot.AddTextBox(binYlabel,0.21,0.85,0.51,0.9,0,kBlack,-1);
     if(sigOnly) plot.AddTextBox(nsigtext,0.21,0.78,0.51,0.73,0,kBlack,-1);
-    else        plot.AddTextBox(0.21,0.78,0.51,0.68,0,kBlack,-1,2,nsigtext,nbkgtext);
+    //    else        plot.AddTextBox(0.21,0.78,0.51,0.68,0,kBlack,-1,2,nsigtext,nbkgtext);
+    else        plot.AddTextBox(nsigtext,0.21,0.78,0.51,0.73,0,kBlack,-1); // this print the fraction now
     if(model==1)      plot.AddTextBox(0.70,0.90,0.95,0.80,0,kBlack,-1,2,mean1text,sig1text);
     else if(model==2) plot.AddTextBox(0.70,0.90,0.95,0.70,0,kBlack,-1,5,mean1text,mean2text,sig0text,sig1text,sig2text);
-    else if(model==3) plot.AddTextBox(0.70,0.90,0.95,0.65,0,kBlack,-1,7,mean1text,mean2text,mean3text,sig0text,sig1text,sig2text,sig3text);
+    //    else if(model==3) plot.AddTextBox(0.70,0.90,0.95,0.65,0,kBlack,-1,7,mean1text,mean2text,mean3text,sig0text,sig1text,sig2text,sig3text);
+    else if(model==3) plot.AddTextBox(0.70,0.90,0.95,0.65,0,kBlack,-1,6,mean1text,mean2text,mean3text,sig1text,sig2text,sig3text);
     plot.Draw(c,kTRUE,"png");
+
+    /*
+    pad2->cd();
+    RooHist* hist = frame->getHist(histo.Data());
+    RooHist* hist_pull = hist->makePullHist(*modelpdf);
+    hist_pull->SetTitle("");
+    hist_pull->SetMarkerColor(kAzure);
+    hist_pull->SetLineColor(kAzure);
+    hist_pull->SetFillColor(kAzure);
+    hist_pull->Draw("A3 L ");
+    */
+
     
     sprintf(pname,"%sfitlog_%i",plabel,ibin);
+    plot.SetYRange(0.1,10*hv[ibin]->GetMaximum());
     plot.SetName(pname);
     plot.SetLogy();
     plot.Draw(c,kTRUE,"png");        
+
+    // reset color canvas
+    c->SetFillColor(kWhite);
+
   }
+
+  return;
+
 }
 
 void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Double_t *ptbins, const Int_t nbins,
@@ -1189,13 +1527,13 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
     RooRealVar u("u","u",hv[ibin]->GetXaxis()->GetXmin(),hv[ibin]->GetXaxis()->GetXmax());name.str(""); 
     u.setBins(100);
     RooDataHist dataHist("dataHist","dataHist",RooArgSet(u),hv[ibin]);
-    
+
     //
     // Set up background histogram templates
     //
     RooDataHist bkgHist("bkgHist","bkgHist",RooArgSet(u),hbkgv[ibin]);
     RooHistPdf bkg("bkg","bkg",u,bkgHist,0);
-    
+
     //
     // Set up fit parameters
     //
@@ -1343,15 +1681,16 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
     std::cout << "sigma1 = " << sigma1.getVal() << std::endl;
     std::cout << "sigma2 = " << sigma2.getVal() << std::endl;
     if(ibin>0)std::cout << "sigma max = " << 1.5*hv[ibin-1]->GetRMS() << " " << 1.8*hv[ibin-1]->GetRMS() << std::endl;
-    
+
     //
     // Perform fit
     //
     RooFitResult *fitResult=0;
     fitResult = modelpdf.fitTo(dataHist,
+			       NumCPU(4),
                                //RooFit::Minos(),
-                   RooFit::Strategy(2),
-                           RooFit::Save());
+			       RooFit::Strategy(2),
+			       RooFit::Save());
     
     if(sigma1.getVal() > sigma2.getVal()) {
       Double_t wide = sigma1.getVal();
@@ -1360,9 +1699,10 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
       sigma2.setVal(wide);
       frac2.setVal(1.0-frac2.getVal());
       fitResult = modelpdf.fitTo(dataHist,
+				 NumCPU(4),
                                  //RooFit::Minos(),
-                     RooFit::Strategy(2),
-                             RooFit::Save());
+				 RooFit::Strategy(2),
+				 RooFit::Save());
     }
     
     mean1Arr[ibin]      = mean1.getVal();
@@ -1398,7 +1738,7 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
     if(model>=2) sig.plotOn(frame,Components("gauss1"),LineStyle(kDashed),LineColor(kRed));
     if(model>=2) sig.plotOn(frame,Components("gauss2"),LineStyle(kDashed),LineColor(kCyan+2));
     if(model>=3) sig.plotOn(frame,Components("gauss3"),LineStyle(kDashed),LineColor(kGreen+2));
-    
+
     sprintf(pname,"%sfit_%i",plabel,ibin);
     sprintf(ylabel,"Events / %.1f GeV",hv[ibin]->GetBinWidth(1));
     sprintf(binlabel,"%i < p_{T} < %i",(Int_t)ptbins[ibin],(Int_t)ptbins[ibin+1]);    
@@ -1428,11 +1768,13 @@ void performFitFM(const vector<TH1D*> hv, const vector<TH1D*> hbkgv, const Doubl
     if(model==1)      plot.AddTextBox(0.70,0.90,0.95,0.80,0,kBlack,-1,2,mean1text,sig1text);
     else if(model==2) plot.AddTextBox(0.70,0.90,0.95,0.70,0,kBlack,-1,5,mean1text,mean2text,sig0text,sig1text,sig2text);
     else if(model==3) plot.AddTextBox(0.70,0.90,0.95,0.65,0,kBlack,-1,7,mean1text,mean2text,mean3text,sig0text,sig1text,sig2text,sig3text);
+    if(fitResult->status()>1) plot.AddTextBox(Form("status=%d",fitResult->status()),0.21,0.5,0.51,0.58,0,kRed,-1);
     plot.Draw(c,kTRUE,"png");
     
     sprintf(pname,"%sfitlog_%i",plabel,ibin);
     plot.SetName(pname);
     plot.SetLogy();
+    if(fitResult->status()>1) plot.AddTextBox(Form("status=%d",fitResult->status()),0.21,0.5,0.51,0.58,0,kRed,-1);
     plot.Draw(c,kTRUE,"png");        
   }
 }

--- a/Recoil/runRecoilFits.sh
+++ b/Recoil/runRecoilFits.sh
@@ -1,21 +1,51 @@
 #! /bin/bash
 
 # INPUTDIR=/afs/cern.ch/work/s/sabrandt/public/SM/
-INPUTDIR=/afs/cern.ch/user/s/sabrandt/work/public/SM/newBacon/
-#/data/blue/Bacon/Run2/wz_flat
+#/afs/cern.ch/user/s/sabrandt/work/public/SM/newBacon/
+INPUTDIR=/afs/cern.ch/work/a/arapyan/public/flat_ntuples
+
 LUMI=2318
+#LUMI=1 #fitting for the fractions
 # muons
- root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/zmm_select.raw.root\",3,3,1,\"puppiU1\",\"puppiU2\",\"puppi\",\"ZmmDataPuppi_testtest\",${LUMI}\) #Zmumu data selection
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/data_select.root\",3,3,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"ZmmDataPuppi_bkg\",${LUMI}\) #Zmumu data/ /BKG selection selection  
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/data_select.root\",3,3,1,\"puppiU1\",\"puppiU2\",\"puppi\",\"ZmmDataPuppi\",${LUMI}\) #Zmumu data selection
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/zmm_select.raw.root\",3,3,1,\"puppiU1\",\"puppiU2\",\"puppi\",\"ZmmMCPuppi\",${LUMI}\) #Zmumu MC selection
+
+# CENTRAL VALUE
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi\",${LUMI},0\) #Wmunu data selection
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi\",${LUMI},0\) #Wmunu data selection
+
+# PileUp systematics
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi_PileupUp\",${LUMI},0\) #Wmunu data selection
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi_PileupDown\",${LUMI},0\) #Wmunu data selection
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi_PileupUp\",${LUMI},0\) #Wmunu data selection
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi_PileupDown\",${LUMI},0\) #Wmunu data selection
+
+# W/Z recoil differences
+###                 int etaBinCategory=0 // 0 is inclusive, 1 is fabs(eta)<=0.5,  2 is fabs(eta)=[0.5,1], 3 is fabs(eta)>=1
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi_rap05\",${LUMI},1\) #Wmunu
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi_rap05\",${LUMI},1\) #Wmunu
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi_rap05-1\",${LUMI},2\) #Wmunu
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi_rap05-1\",${LUMI},2\) #Wmunu
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMCPuppi_rap1\",${LUMI},3\) #Wmunu
+#root -l -b -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMCPuppi_rap1\",${LUMI},3\) #Wmunu
+
+
+## below old configs from stephanie
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/data_select.root\",3,3,0,\"u1\",\"u2\",\"pf\",\"ZmmDataPF_bkg\",${LUMI}\) #Zmumu data/ /BKG selection selection  
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/data_select.root\",3,3,1,\"u1\",\"u2\",\"pf\",\"ZmmDataPF\",${LUMI}\) #Zmumu data selection
+#root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/zmm_select.raw.root\",3,3,1,\"u1\",\"u2\",\"pf\",\"ZmmMCPF\",${LUMI}\) #Zmumu MC selection
+
 #   root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/zmm_select.raw.root\",3,3,1,\"puppiU1\",\"puppiU2\",\"puppi\",\"ZmmMCPuppi_newBacon_eta1\"\) #Zmumu data selection
 # root -l -q fitRecoilZmm.C+\(\"${INPUTDIR}/Zmumu/ntuples/data_select.root\",2,2,1,\"ppU1\",\"ppU2\",\"t1pf\",\"ZmmData\"\) #Zmumu data selection
 # root -l -q fitRecoilWm3.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmpMC_newBacon\"\) #Wmunu data selection
 # root -l -q fitRecoilWm3.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",3,3,1,-1,0,\"puppiU1\",\"puppiU2\",\"puppi\",\"WmmMC_newBacon\"\) #Wmunu data selection
- #root -l -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",2,2,1,-1,0,\"mvaU1\",\"mvaU2\",\"mva\",\"WmmMC\"\) #Wmunu signal MC -
+# root -l -q fitRecoilWm.C+\(\"${INPUTDIR}/Wmunu/ntuples/\",2,2,1,-1,0,\"mvaU1\",\"mvaU2\",\"mva\",\"WmmMC\"\) #Wmunu signal MC -
 
 # electrons
 #   root -l -q fitRecoilZee.C+\(\"${INPUTDIR}/Zee/ntuples/data_select.raw.root\",2,2,1,\"mvaU1\",\"mvaU2\",\"mva\",\"ZeeData\"\) #Zmumu data selection
- #root -l -q fitRecoilZee.C+\(\"${INPUTDIR}/Zee/ntuples/zee_select.root\",2,2,1,\"ZeeMC\"\) #Zee signal MC selection
-#root -l -q fitRecoilWe.C+\(\"${INPUTDIR}/Wenu/ntuples/\",2,2,1,1,0,\"mvaU1\",\"mvaU2\",\"mva\"\"WepMC\"\) #Wenu +
-#root -l -q fitRecoilWe.C+\(\"${INPUTDIR}/Wenu/ntuples/\",2,2,1,-1,0,\"mvaU1\",\"mvaU2\",\"mva\"\"WemMC\"\) #Wenu signal MC -
+# root -l -q fitRecoilZee.C+\(\"${INPUTDIR}/Zee/ntuples/zee_select.root\",2,2,1,\"ZeeMC\"\) #Zee signal MC selection
+# root -l -q fitRecoilWe.C+\(\"${INPUTDIR}/Wenu/ntuples/\",2,2,1,1,0,\"mvaU1\",\"mvaU2\",\"mva\"\"WepMC\"\) #Wenu +
+# root -l -q fitRecoilWe.C+\(\"${INPUTDIR}/Wenu/ntuples/\",2,2,1,-1,0,\"mvaU1\",\"mvaU2\",\"mva\"\"WemMC\"\) #Wenu signal MC -
 
 rm *.so *.d *.pcm

--- a/Utils/RecoilCorrector_asym2.hh
+++ b/Utils/RecoilCorrector_asym2.hh
@@ -21,6 +21,7 @@
 #include "RooDataSet.h"
 #include "RooAbsPdf.h"
 #include "RooAddPdf.h"
+#include "RooKeysPdf.h"
 #include "RooProdPdf.h"
 #include "RooPlot.h"
 #include "RooFitResult.h"
@@ -52,12 +53,14 @@ public:
   RecoilCorrector(string iNameZDat, int iSeed=0xDEADBEEF);
   RecoilCorrector(string iNameZDat1, string iPrefix, int iSeed=0xDEADBEEF);
     
+  void loadRooWorkspacesMCtoCorrectKeys(string iNameFile);
+  void loadRooWorkspacesMCtoCorrect(string iNameFile);
   void loadRooWorkspacesMC(string iNameFile);
   void loadRooWorkspacesData(string iNameFile);
   
   void CorrectType0(double &pfmet, double &pfmetphi,double iGenPt,double iGenPhi,double iLepPt,double iLepPhi,double &iU1,double &iU2,double iFluc,double iScale=0,int njet=0);
   void CorrectType2(double &pfmet, double &pfmetphi,double iGenPt,double iGenPhi,double iLepPt,double iLepPhi,double &iU1,double &iU2,double iFluc,double iScale=0,int njet=0);
-  void CorrectInvCdf(double &pfmet, double &pfmetphi,double iGenPt,double iGenPhi,double iLepPt,double iLepPhi,double &iU1,double &iU2,double iFluc,double iScale=0,int njet=0);
+  void CorrectInvCdf(double &pfmet, double &pfmetphi,double iGenPt,double iGenPhi,double iLepPt,double iLepPhi,double &iU1,double &iU2,double iFluc,double iScale=0,int njet=0, bool dokeys=false);
   void CorrectFromToys(double &pfmet, double &pfmetphi,double iGenPt,double iGenPhi,double iLepPt,double iLepPhi,double &iU1,double &iU2,double iFluc,double iScale=0,int njet=0);
   void addDataFile(std::string iNameDat);
   void addMCFile  (std::string iNameMC);
@@ -212,17 +215,24 @@ protected:
   
   RooWorkspace* rooWData[2];
   RooWorkspace* rooWMC[2];
+  RooWorkspace* rooWMCtoCorr[2];
   RooWorkspace* pdfsU1zData, pdfsU2zData;
   RooWorkspace* pdfsU1zMC, pdfsU2zMC;
   RooWorkspace* pdfsU1sigMC, pdfsU2sigMC;
   int fId; int fJet;
+  bool dokeys;
   
   RooWorkspace rooWksDataU1;
   RooWorkspace rooWksMCU1;
   RooWorkspace rooWksDataU2;
   RooWorkspace rooWksMCU2;
   
-  std::vector<double> vZPtBins;
+  // oct2 binning
+  //  std::vector<double> vZPtBins ={0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,62.5,65,67.5,70,72.5,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
+
+  // oct7 binning
+  std::vector<double> vZPtBins ={0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,65,70,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
+
 //   Double_t vZPtBins[] = {0,1,2.5,5.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,62.5,65,67.5,70,72.5,75,77.5,80,82.5,85,87.5,90,92.5,95,97.5,100};
 // int nZPtBins = sizeof(vZPtBins)/sizeof(Double_t)-1;
 
@@ -247,7 +257,6 @@ RecoilCorrector::RecoilCorrector(string iNameZ, int iSeed) {
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
 void RecoilCorrector::loadRooWorkspacesData(std::string iFName){
-  vZPtBins ={0,0.5,1.0,1.5,2.0,2.5,3.0,4.0,5.0,6.0,7.5,10,12.5,15,17.5,20,22.5,25,27.5,30,32.5,35,37.5,40,42.5,45,47.5,50,52.5,55,57.5,60,62.5,65,67.5,70,72.5,75,80,85,90,95,100,110,120,130,140,150,160,170,180,190,200,210,220,230,240,250,275,300};
   
   TFile *lFile  = new TFile((iFName+"pdfsU1.root").c_str());
   rooWData[0] = (RooWorkspace*) lFile->Get("pdfsU1");
@@ -268,7 +277,9 @@ void RecoilCorrector::loadRooWorkspacesData(std::string iFName){
     RooAbsReal *cdfU2 = pdf2->createCdf(*myX2);
     rooWData[1]->import(*cdfU2, RooFit::Silence());
   }
+  std::cout << "Loaded WorkspacesDATA "<< std::endl;
 }
+
 void RecoilCorrector::loadRooWorkspacesMC(std::string iFName){
   TFile *lFile  = new TFile((iFName+"pdfsU1.root").c_str());
   rooWMC[0] = (RooWorkspace*) lFile->Get("pdfsU1");
@@ -289,7 +300,64 @@ void RecoilCorrector::loadRooWorkspacesMC(std::string iFName){
     RooAbsReal *cdfU2 = pdf2->createCdf(*myX2);
     rooWMC[1]->import(*cdfU2, RooFit::Silence());
   }
+  std::cout << "Loaded WorkspacesMC "<< std::endl;
 }
+
+void RecoilCorrector::loadRooWorkspacesMCtoCorrect(std::string iFName){
+
+  TFile *lFile  = new TFile((iFName+"pdfsU1.root").c_str());
+  rooWMCtoCorr[0] = (RooWorkspace*) lFile->Get("pdfsU1");
+  lFile->Delete();
+  TFile *lFile2  = new TFile((iFName+"pdfsU2.root").c_str());
+  rooWMCtoCorr[1] = (RooWorkspace*) lFile2->Get("pdfsU2");
+  lFile2->Delete();
+  for(uint i = 0; i < vZPtBins.size()-1; ++i){
+    std::stringstream name;
+    name << "sig_" << i;
+    RooAbsPdf* pdf1 = rooWMCtoCorr[0]->pdf(name.str().c_str());
+    RooAbsPdf* pdf2 = rooWMCtoCorr[1]->pdf(name.str().c_str());
+    name.str(""); name << "u_" << i;
+    RooRealVar* myX1 = (RooRealVar*) rooWMCtoCorr[0]->var(name.str().c_str());
+    RooRealVar* myX2 = (RooRealVar*) rooWMCtoCorr[1]->var(name.str().c_str());
+    RooAbsReal *cdfU1 = pdf1->createCdf(*myX1);
+    rooWMCtoCorr[0]->import(*cdfU1, RooFit::Silence());
+    RooAbsReal *cdfU2 = pdf2->createCdf(*myX2);
+    rooWMCtoCorr[1]->import(*cdfU2, RooFit::Silence());
+  }
+  std::cout << "Loaded WorkspacesMCtoCorrec "<< std::endl;
+}
+
+
+void RecoilCorrector::loadRooWorkspacesMCtoCorrectKeys(std::string iFName){
+
+  //  RooKeysPdf::key_44
+
+  TFile *lFile  = new TFile((iFName+"pdfsU1.root").c_str());
+  rooWMCtoCorr[0] = (RooWorkspace*) lFile->Get("pdfsU1");
+  lFile->Delete();
+  TFile *lFile2  = new TFile((iFName+"pdfsU2.root").c_str());
+  rooWMCtoCorr[1] = (RooWorkspace*) lFile2->Get("pdfsU2");
+  lFile2->Delete();
+  for(uint i = 0; i < vZPtBins.size()-1; ++i){
+    std::stringstream name;
+    name << "key_" << i ;
+    //    RooAbsPdf* pdf1 = (RooKeysPdf*) lFile->Get(name.str().c_str());
+    //    RooAbsPdf* pdf2 = (RooKeysPdf*) lFile2->Get(name.str().c_str());
+    RooAbsPdf* pdf1 = (RooKeysPdf*) rooWMCtoCorr[0]->pdf(name.str().c_str());
+    RooAbsPdf* pdf2 = (RooKeysPdf*) rooWMCtoCorr[1]->pdf(name.str().c_str());
+    name.str(""); name << "u_" << i;
+    //    name.str(""); name << "u";
+    RooRealVar* myX1 = (RooRealVar*) rooWMCtoCorr[0]->var(name.str().c_str());
+    RooRealVar* myX2 = (RooRealVar*) rooWMCtoCorr[1]->var(name.str().c_str());
+    RooAbsReal *cdfU1 = pdf1->createCdf(*myX1);
+    rooWMCtoCorr[0]->import(*cdfU1, RooFit::Silence());
+    RooAbsReal *cdfU2 = pdf2->createCdf(*myX2);
+    rooWMCtoCorr[1]->import(*cdfU2, RooFit::Silence());
+  }
+  std::cout << "Loaded WorkspacesMCtoCorrect with keys"<< std::endl;
+}
+
+
 
 void RecoilCorrector::addDataFile(std::string iNameData) {
   readRecoil(fD1U1Fit,fD1U1RMSSMFit,fD1U1RMS1Fit,fD1U1RMS2Fit,fD1U2Fit,fD1U2RMSSMFit,fD1U2RMS1Fit,fD1U2RMS2Fit,iNameData,"fcnPF",0);
@@ -344,7 +412,8 @@ void RecoilCorrector::CorrectType2(double &met, double &metphi, double lGenPt, d
                iU1,iU2,iFluc,iScale);
 }
 
-void RecoilCorrector::CorrectInvCdf(double &met, double &metphi, double lGenPt, double lGenPhi, double lepPt, double lepPhi,double &iU1,double &iU2,double iFluc,double iScale,int njet) {  
+void RecoilCorrector::CorrectInvCdf(double &met, double &metphi, double lGenPt, double lGenPhi, double lepPt, double lepPhi,double &iU1,double &iU2,double iFluc,double iScale,int njet, bool useKeys) {
+  dokeys=useKeys;
   fJet = njet; if(njet > 2) fJet = 2;
   if(fJet >= int(fF1U1Fit.size())) fJet = 0; 
 
@@ -572,7 +641,13 @@ double RecoilCorrector::triGausInvGraphPDF(double iPVal, double Zpt, RooAbsReal 
 // std::cout << "-------" << std::endl;
 // std::cout << "ipval " << iPVal << std::endl;
 // std::cout << "max " << max << std::endl;
-  if(TMath::Abs(iPVal-max)>=400) return iPVal;
+// this should be in synch with the recoil fits
+// now binning with -100,100 http://dalfonso.web.cern.ch/dalfonso/WZ/sept28/ZmmMCPuppi/plots/pfu2fit_10.png
+//  std::cout << " MIN=" << myXm->getMin() << " MAX=" << myXm->getMax() << std::endl;
+
+  if(iPVal< myXm->getMin()) return iPVal;
+  if(iPVal> myXm->getMax()) return iPVal;
+
   myXm->setVal(iPVal);
   double pVal=pdfDATAcdf->findRoot(*myXd,myXd->getMin(),myXd->getMax(),pdfMCcdf->getVal());
 //   std::cout << "pVal " << pVal << std::endl;
@@ -762,7 +837,7 @@ void RecoilCorrector::metDistributionInvCdf(double &iMet,double &iMPhi,double iG
                        TGraphErrors *iU1Default,
                        double &iU1,double &iU2,double iFluc,double iScale) {
   
-  double pDefU1    = iU1Default->Eval(iGenPt);
+  //  double pDefU1    = iU1Default->Eval(iGenPt);
 
   double iGenPt2 = 0;
   Int_t nbinsPt = vZPtBins.size()-1;
@@ -788,48 +863,90 @@ void RecoilCorrector::metDistributionInvCdf(double &iMet,double &iMPhi,double iG
   double pU   = sqrt(pUX*pUX+pUY*pUY);
   double pCos = - (pUX*cos(iGenPhi) + pUY*sin(iGenPhi))/pU;
   double pSin =   (pUX*sin(iGenPhi) - pUY*cos(iGenPhi))/pU;
-  double pU1   = pU*pCos; // U1 in data
-  double pU2   = pU*pSin; // U2 in data
-  double pU1Diff  = pU1-pDefU1; // subtract the mean1 from MC?
-//   double pU1Diff2  = pU1-pDefU1_2; // subtract the mean2 also from MC?
-//   double pU1MeanDiff = pDefU1-pDefU1_2;
-  double pU2Diff  = pU2; // don't care because expect mean to be ~0
-  double p1Charge        = pU1Diff/fabs(pU1Diff);
-  double p2Charge        = pU2Diff/fabs(pU2Diff);
-  double pTU1Diff        = pU1Diff;
+  double pU1  = pU*pCos; // U1 in sample to Correct (WMC or ZMC)
+  double pU2  = pU*pSin; // U2 in sample to Correct (WMC or ZMC)
+  //  double pU1Diff  = pU1-pDefU1; // subtract the mean1 from MC?            // not used
+  //  double pU1Diff2  = pU1-pDefU1_2; // subtract the mean2 also from MC?
+  //  double pU1MeanDiff = pDefU1-pDefU1_2;
+  //  double pU2Diff  = pU2; // don't care because expect mean to be ~0       // not used
+  //  double p1Charge        = pU1Diff/fabs(pU1Diff);                     // not used
+  //  double p2Charge        = pU2Diff/fabs(pU2Diff);                     // not used
+  //  double pTU1Diff        = pU1Diff;                                   // not used
 
-  
-  
+
   std::stringstream name;
   name << "sig_" << iBin;
   RooAbsPdf *thisPdfDataU1 = rooWData[0]->pdf(name.str().c_str()); name.str("");
   name << "sig_" << iBin;
   RooAbsPdf *thisPdfMCU1 = rooWMC[0]->pdf(name.str().c_str()); name.str("");
+
   name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
   RooAbsReal *thisCdfDataU1 = rooWData[0]->function(name.str().c_str()); name.str("");
   name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
   RooAbsReal *thisCdfMCU1 = rooWMC[0]->function(name.str().c_str()); name.str("");
+
   name << "sig_" << iBin;
   RooAbsPdf *thisPdfDataU2 = rooWData[1]->pdf(name.str().c_str()); name.str("");
   name << "sig_" << iBin;
   RooAbsPdf *thisPdfMCU2 = rooWMC[1]->pdf(name.str().c_str()); name.str("");
+
   name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
   RooAbsReal *thisCdfDataU2 = rooWData[1]->function(name.str().c_str()); name.str("");
   name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
   RooAbsReal *thisCdfMCU2 = rooWMC[1]->function(name.str().c_str()); name.str("");
-  
+
+  RooAbsPdf *thisPdfMCU1toCorr;
+  RooAbsReal *thisCdfMCU1toCorr;
+  RooAbsPdf *thisPdfMCU2toCorr;
+  RooAbsReal *thisCdfMCU2toCorr;
+
+  if(!dokeys) {
+
+    name << "sig_" << iBin;
+    thisPdfMCU1toCorr = rooWMCtoCorr[0]->pdf(name.str().c_str()); name.str("");
+
+    name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
+    thisCdfMCU1toCorr = rooWMCtoCorr[0]->function(name.str().c_str()); name.str("");
+    name << "sig_" << iBin;
+    thisPdfMCU2toCorr = rooWMCtoCorr[1]->pdf(name.str().c_str()); name.str("");
+    name << "sig_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
+    thisCdfMCU2toCorr = rooWMCtoCorr[1]->function(name.str().c_str()); name.str("");
+
+  } else {
+
+    name << "key_" << iBin;
+    thisPdfMCU1toCorr = rooWMCtoCorr[0]->pdf(name.str().c_str()); name.str("");
+
+    name << "key_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
+    thisCdfMCU1toCorr = rooWMCtoCorr[0]->function(name.str().c_str()); name.str("");
+    name << "key_" << iBin;
+    thisPdfMCU2toCorr = rooWMCtoCorr[1]->pdf(name.str().c_str()); name.str("");
+    name << "key_" << iBin <<"_cdf_Int[u_"<< iBin<< "_prime|CDF]_Norm[u_"<< iBin<< "_prime]";
+    thisCdfMCU2toCorr = rooWMCtoCorr[1]->function(name.str().c_str()); name.str("");
+
+  }
+
   std::stringstream varName;
   varName.str("");varName << "u_"<<iBin;
   RooRealVar* myXdU1 =  (RooRealVar*) rooWData[0]->var(varName.str().c_str());
   RooRealVar* myXmU1 =  (RooRealVar*) rooWMC[0]->var(varName.str().c_str());
+  RooRealVar* myXmcU1 =  (RooRealVar*) rooWMCtoCorr[0]->var(varName.str().c_str());
   RooRealVar* myXdU2 =  (RooRealVar*) rooWData[1]->var(varName.str().c_str());
   RooRealVar* myXmU2 =  (RooRealVar*) rooWMC[1]->var(varName.str().c_str());
+  RooRealVar* myXmcU2 =  (RooRealVar*) rooWMCtoCorr[1]->var(varName.str().c_str());
   
-  double pU1ValD = triGausInvGraphPDF(pU1,iGenPt,thisCdfMCU1,thisCdfDataU1,thisPdfMCU1,thisPdfDataU1,myXdU1,myXmU1,iBin,pDefU1);
-  double pU2ValD = triGausInvGraphPDF(pU2,iGenPt,thisCdfMCU2,thisCdfDataU2,thisPdfMCU2,thisPdfDataU2,myXdU2,myXmU2,iBin,0);
+  // invert the target MC (W/Z) to the (ZMC)
+  // for the closure on Z events: this step should give pU1ValMzlike=pU1
+  double pU1ValMzlike = triGausInvGraphPDF(pU1,iGenPt,thisCdfMCU1toCorr,thisCdfMCU1,thisPdfMCU1toCorr,thisPdfMCU1,myXmU1,myXmcU1,iBin,0);
+  double pU2ValMzlike = triGausInvGraphPDF(pU2,iGenPt,thisCdfMCU2toCorr,thisCdfMCU2,thisPdfMCU2toCorr,thisPdfMCU2,myXmU2,myXmcU2,iBin,0);
 
-  pU1   = /*pDefU1             +*/ pU1ValD;
-  pU2   =                      pU2ValD;
+  // invert the target MC (Z) to the (ZDATA)
+  double pU1ValDzlike = triGausInvGraphPDF(pU1ValMzlike,iGenPt,thisCdfMCU1,thisCdfDataU1,thisPdfMCU1,thisPdfDataU1,myXdU1,myXmU1,iBin,0);
+  double pU2ValDzlike = triGausInvGraphPDF(pU2ValMzlike,iGenPt,thisCdfMCU2,thisCdfDataU2,thisPdfMCU2,thisPdfDataU2,myXdU2,myXmU2,iBin,0);
+
+  // have the newW recoil as WrecoilMC + Difference in Zdata/MC
+  pU1   = pU1 + ( pU1ValDzlike - pU1ValMzlike);
+  pU2   = pU2 + ( pU2ValDzlike - pU2ValMzlike);
   iMet  = calculate(0,iLepPt,iLepPhi,iGenPhi,pU1,pU2);
   iMPhi = calculate(1,iLepPt,iLepPhi,iGenPhi,pU1,pU2);
   


### PR DESCRIPTION
Changes to the macro to derive the recoil correction Recoil/fitRecoilZmm.C and Recoil/fitRecoilWm.C:
- various aestetics
- bkg subtraction
- various ranges / initial values/ binning
- rapidity binned
- rookeys

Changes to the application  of the recoil
1) Utils/RecoilCorrector_asym2.hh 
2) SignalExtraction/fitZm.C this is the most update to date need to propagate the changes here to the other macros

@sabrandt @arapyan 
